### PR TITLE
feat(fzf): actions, overlay hints, and instant jump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Shellcheck
-        run: |
-          # Shellcheck with zsh-specific exclusions
-          shellcheck -s bash -e SC1071,SC2034,SC2296,SC2168,SC2154,SC1090,SC2086 \
-            zsh-jumper.plugin.zsh || true
-          echo "Shellcheck completed (warnings only for zsh)"
+      - name: Install zsh
+        run: sudo apt-get update && sudo apt-get install -y zsh
+
+      - name: Syntax check
+        run: zsh -n zsh-jumper.plugin.zsh
 
   test:
     runs-on: ${{ matrix.os }}
@@ -72,9 +71,7 @@ jobs:
         run: |
           zsh -c '
             source ./zsh-jumper.plugin.zsh
-            # Should return empty/error without picker
-            result=$(_zsh_jumper_detect_picker 2>&1)
-            [[ -z "$result" ]] && echo "Correctly returns empty when no picker" && exit 0
-            echo "Unexpected: $result"
+            [[ -z "${ZshJumper[picker]}" ]] && echo "Correctly empty when no picker" && exit 0
+            echo "Unexpected: ${ZshJumper[picker]}"
             exit 1
           '

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: test test-verbose lint
+
+test:
+	@zsh tests/test_plugin.zsh
+
+test-verbose:
+	@zsh tests/test_plugin.zsh --verbose
+
+lint:
+	@zsh -n zsh-jumper.plugin.zsh

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,237 @@
+# Design Principles
+
+Engineering notes on zsh-jumper's architecture.
+
+## Core Philosophy
+
+**Pure shell logic, external tools only for UI.**
+
+The tokenizer, position tracking, and buffer manipulation are pure zsh - no external dependencies. FZF/skim/peco are only used for the fuzzy picker UI.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│                   zsh-jumper-widget                 │
+│         (orchestration, overlay, instant mode)      │
+└─────────────────────┬───────────────────────────────┘
+                      │
+        ┌─────────────┼─────────────┐
+        ▼             ▼             ▼
+┌───────────┐  ┌───────────┐  ┌─────────────────┐
+│ tokenizer │  │  actions  │  │ picker adapters │
+│  (pure)   │  │  (pure)   │  │ (ports pattern) │
+└───────────┘  └───────────┘  └─────────────────┘
+                                      │
+                    ┌─────────┬───────┼───────┬─────────┐
+                    ▼         ▼       ▼       ▼         ▼
+                  fzf    fzf-tmux    sk     peco    percol
+```
+
+**Layers:**
+
+1. **Tokenizer** - Pure zsh. Parses BUFFER, produces parallel arrays
+2. **Actions** - Pure zsh. Jump, wrap, help, var, replace
+3. **Picker Adapters** - Ports & adapters pattern. Same interface, different backends
+4. **Widget** - Orchestration. Overlay hints, instant mode, glues layers together
+
+## Configuration
+
+Config read once at plugin load, stored in `ZshJumper` associative array:
+
+```zsh
+_zsh_jumper_load_config() {
+    zstyle -s ':zsh-jumper:' overlay val; ZshJumper[overlay]="${val:-on}"
+    zstyle -s ':zsh-jumper:' fzf-wrap-key val; ZshJumper[wrap-key]="${val:-ctrl-s}"
+    # ... etc
+}
+```
+
+**Why load once?** Reading zstyle during widget execution caused output leakage in some terminal configurations.
+
+## Picker Adapters (Ports & Adapters)
+
+Each adapter implements the same interface:
+
+```zsh
+# Input: stdin (items), _zj_invoke_* variables (config)
+# Output: _zj_result_key (action), _zj_result_selection (item)
+# Return: 0 success, 1 cancelled
+
+_zsh_jumper_adapter_fzf()
+_zsh_jumper_adapter_fzf-tmux()
+_zsh_jumper_adapter_sk()
+_zsh_jumper_adapter_peco()
+_zsh_jumper_adapter_percol()
+```
+
+Adding a new picker = implement one function.
+
+## Overlay & Instant Mode
+
+EasyMotion-style hints via `region_highlight`:
+
+```zsh
+_zsh_jumper_highlight_hints() {
+    region_highlight=()
+    # Find [x] patterns, add "fg=yellow,bold" highlighting
+}
+```
+
+Instant mode uses fzf's `rebind` action - letter keys start unbound, `;` rebinds them for direct jump.
+
+## Tokenizer Design
+
+### Scope (intentional constraints)
+
+This tokenizer is **word-based, not shell-grammar-aware**.
+
+- Splits on whitespace only
+- Quotes are literal characters, not delimiters
+- `echo "hello world"` produces 3 tokens: `echo`, `"hello`, `world"`
+- Escapes, subshells, variable expansion - all out of scope
+
+This is intentional. Shell grammar parsing is a different beast entirely - state machines, nested quotes, escape handling. That's a v2 tokenizer, not an extension of this one.
+
+### Problem
+
+The naive approach `words=(${=BUFFER})` loses position information. To place the cursor correctly, we need to know where each word starts in the original buffer.
+
+### Failed Approaches
+
+**Search-based position finding:**
+```zsh
+# Find position by searching through buffer
+pos="${remaining[(i)$target]}"
+```
+
+Problems:
+- Pattern matching fails on special chars (`--flag`, `$VAR`)
+- O(n) per lookup, O(n²) total
+- Edge cases with duplicate words
+
+### Solution: Single-Pass Tokenizer
+
+Parse once, record positions during tokenization:
+
+```zsh
+_zsh_jumper_tokenize() {
+    _zj_words=()
+    _zj_positions=()
+
+    local i=0 word_start=-1 in_word=0
+    while (( i < ${#BUFFER} )); do
+        if [[ "${BUFFER:$i:1}" == [[:space:]] ]]; then
+            if (( in_word )); then
+                _zj_words+=("${BUFFER:$word_start:$((i - word_start))}")
+                _zj_positions+=($word_start)
+                in_word=0
+            fi
+        elif (( ! in_word )); then
+            word_start=$i
+            in_word=1
+        fi
+        (( i++ ))
+    done
+    # Handle trailing word...
+}
+```
+
+**Benefits:**
+- O(n) single pass
+- O(1) position lookup: `_zj_positions[$idx]`
+- No pattern matching - handles all characters
+- Parallel arrays keep data aligned
+
+### Edge Cases Handled
+
+| Input | Behavior |
+|-------|----------|
+| Multiple spaces | Skipped, positions correct |
+| Leading/trailing space | Trimmed, first word positioned correctly |
+| Tabs, newlines | Treated as whitespace |
+| `--flag` | Literal match, no pattern issues |
+| `VAR=value` | Single token, equals preserved |
+| `$VAR` | Literal, no expansion |
+| 500+ words | O(n), tested |
+
+## Action Design
+
+Actions receive only the selection string. They access `_zj_words` and `_zj_positions` directly:
+
+```zsh
+_zsh_jumper_do_jump() {
+    local sel="$1"
+    local idx="${sel%%:*}"
+
+    # Bounds check
+    (( idx < 1 || idx > ${#_zj_words[@]} )) && return 1
+
+    # Direct lookup - O(1)
+    local pos="${_zj_positions[$idx]}"
+    CURSOR=$pos
+}
+```
+
+**Why not pass arrays as arguments?**
+
+- Simpler function signatures
+- Avoids argument parsing bugs (the `--` separator issue)
+- Arrays are already scoped to the widget invocation
+
+## Testing Strategy
+
+57 tests covering:
+
+1. **Unit tests** - Tokenizer in isolation
+2. **Edge cases** - Unicode, special chars, long strings
+3. **Integration** - Full widget behavior
+4. **Regression** - Specific bugs (e.g., `--` in commands)
+
+Tests run in isolated zsh subshells:
+```zsh
+result=$(zsh -c '
+    source ./zsh-jumper.plugin.zsh
+    BUFFER="test input"
+    _zsh_jumper_tokenize
+    echo "${_zj_positions[1]}"
+')
+```
+
+**Why subshells?**
+- Clean state per test
+- No cross-test pollution
+- Matches real plugin loading
+
+## Lessons Learned
+
+1. **Avoid `||` for defaults in zsh widgets** - Can trigger trace output
+2. **Pattern matching is fragile** - Use character iteration for reliability
+3. **Test the tokenizer separately** - Most bugs are position-related
+4. **Parallel arrays > objects** - Zsh doesn't have objects, parallel arrays work well
+
+## Failure Modes
+
+Where we deliberately do nothing:
+
+| Scenario | Behavior | Rationale |
+|----------|----------|-----------|
+| BUFFER changes mid-flow | Undefined | Widget is synchronous, shouldn't happen |
+| Empty BUFFER | Early return | Nothing to jump to |
+| Index out of bounds | Return 1, no-op | Guard in every action |
+| Picker cancelled | Redisplay, no-op | User intent is clear |
+
+Invariants the widget relies on:
+- BUFFER is stable during widget execution
+- `_zj_words` and `_zj_positions` are aligned (same length)
+- Positions are valid indices into current BUFFER
+
+## Future Considerations
+
+**v2 scope (separate tokenizer, not extension):**
+- Quote-aware tokenization - state machine, escape handling, nested quotes
+- Would need feature flag and aggressive tests
+
+**Smaller additions:**
+- Syntax highlighting - colors for flags, paths, vars
+- History integration - jump to words from previous commands

--- a/response.md
+++ b/response.md
@@ -1,0 +1,20 @@
+Thanks so much for taking the time to write this detailed issue and test my plugin! Really appreciate the thoughtful feedback.
+
+Our goals diverge slightly - with [this PR](https://github.com/Piotr1215/zsh-jumper/pull/3) I'm doubling down on fzf integration with various actions:
+- **Wrap** (`Ctrl+S`): surround token in quotes, `$(...)`, `${...}`, etc
+- **Variable extraction** (`Ctrl+E`): convert `my-value` → `MY_VALUE="my-value"` with `"$MY_VALUE"` in command
+- **Replace** (`Ctrl+R`): delete token and position cursor for tab-completion replacement
+- **Help** (`Ctrl+H`): show `--help` for flags/commands
+
+Your [zsh-easymotion](https://github.com/DehanLUO/.config/blob/main/zsh/zsh-easymotion/zsh-easymotion.zsh) implementation is great! I adopted the `region_highlight` approach for colored hint labels. I've combined it with the fzf picker as an opt-in instant mode - press `;` in fzf to toggle it, then letter keys jump directly. The instant key is configurable via `zstyle ':zsh-jumper:' fzf-instant-key`.
+
+Thanks for the error report about fzf-tmux - I primarily use fzf-tmux in tmux but hadn't tested all code paths. Fixed now. Tested on Alacritty with tmux and Ghostty without tmux.
+
+Architecture-wise, I went with ports & adapters pattern ([design doc](https://github.com/Piotr1215/zsh-jumper/blob/main/docs/design.md)) - clean split between:
+- Pure zsh tokenizer (single-pass, records positions during parsing)
+- Action handlers (jump/wrap/var/replace - O(1) position lookup)
+- Picker adapters (fzf/sk/peco/percol)
+
+This keeps core logic testable and picker-agnostic. See the [README](https://github.com/Piotr1215/zsh-jumper#readme) for full usage docs.
+
+Would love more feedback and ideas from you! The overlay + instant mode combo feels pretty good now.

--- a/tests/fixtures/multiline_cases.txt
+++ b/tests/fixtures/multiline_cases.txt
@@ -1,0 +1,16 @@
+# Multiline command test cases
+# Format: input<TAB>expected_count<TAB>expected_positions
+# Use <NL> for newline (backslash before <NL> is filtered by tokenizer)
+
+# Basic continuation
+docker run \<NL>  -d	3	0 7 15
+kubectl get \<NL>  pods	3	0 8 16
+
+# Multiple continuations
+cmd \<NL>  arg1 \<NL>  arg2	3	0 8 17
+
+# With flags
+docker run \<NL>  --name foo \<NL>  -d	5	0 7 15 22 30
+
+# Simple newline (no backslash)
+echo \<NL>foo	2	0 7

--- a/tests/fixtures/replace_cases.txt
+++ b/tests/fixtures/replace_cases.txt
@@ -1,0 +1,34 @@
+# Replace action test cases
+# Format: input<TAB>token_idx<TAB>expected_buffer<TAB>expected_cursor
+# TAB-separated to allow special characters
+
+# Basic replace
+echo foo bar	2	echo  bar	5
+hello world	1	 world	0
+
+# Replace with multiple spaces
+echo    foo     bar	2	echo         bar	8
+
+# Replace first word
+kubectl get pods	1	 get pods	0
+
+# Replace last word
+echo hello world	3	echo hello 	11
+
+# Replace middle word
+a b c d e	3	a b  d e	4
+
+# Special characters preserved around replaced token
+echo --flag=value next	2	echo  next	5
+"quoted" rest	1	 rest	0
+
+# Emojis
+🚀 launch pad	2	🚀  pad	2
+echo 👋 world	2	echo  world	5
+
+# Pipes and redirects (removing pipe leaves spaces on both sides)
+cat | grep	2	cat  grep	4
+a | b | c	3	a |  | c	4
+
+# Long tokens
+echo superlongwordwithlotsofcharacters end	2	echo  end	5

--- a/tests/fixtures/tokenizer_edge_cases.txt
+++ b/tests/fixtures/tokenizer_edge_cases.txt
@@ -1,0 +1,62 @@
+# Tokenizer invariant: whitespace = token boundary
+# Format: input<TAB>expected_word_count<TAB>expected_positions
+# TAB-separated to allow | in test data
+
+# Basic
+echo foo bar	3	0 5 9
+single	1	0
+
+# Multiple spaces
+echo    foo     bar	3	0 8 16
+a  b  c	3	0 3 6
+
+# Leading/trailing
+   leading	1	3
+trailing   	1	0
+
+# Quotes are just characters
+"hello"	1	0
+'single'	1	0
+"""""""	1	0
+''''''	1	0
+
+# Pipes are just characters (no space = one token)
+cat|grep	1	0
+a|b|c	1	0
+
+# Pipes WITH spaces = multiple tokens
+cat | grep	3	0 4 6
+a | b | c	5	0 2 4 6 8
+
+# Symbols
+!@#$%^&*()	1	0
+--flag=value	1	0
+key=val	1	0
+http://url.com/path	1	0
+user@host:path	1	0
+
+# Unicode - positions are character-based
+hello world	2	0 6
+abc def	2	0 4
+
+# Emojis (positions are character-based, emoji = 1 char)
+🚀 launch	2	0 2
+echo 👋	2	0 5
+🎉🎊🎁	1	0
+a 🔥 b	3	0 2 4
+
+# Non-printable / control chars (bell, escape)
+abc	1	0
+def	1	0
+
+# Backslash (not shell-interpreted, just chars)
+echo\ foo	2	0 6
+path\ with\ spaces	3	0 6 12
+foo\\bar	1	0
+\\	1	0
+a\tb\nc	1	0
+
+# Real commands
+git commit -m message	4	0 4 11 14
+kubectl get pods	3	0 8 12
+echo --flag	2	0 5

--- a/tests/fixtures/var_cases.txt
+++ b/tests/fixtures/var_cases.txt
@@ -1,0 +1,32 @@
+# Var extraction test cases
+# Format: input<TAB>token_idx<TAB>expected_var_name<TAB>expected_buffer_after_replace
+# TAB-separated to allow special characters
+
+# Basic
+echo foo bar	2	FOO	echo "$FOO" bar
+hello world	1	HELLO	"$HELLO" world
+
+# Dashes become underscores
+my-variable	1	MY_VARIABLE	"$MY_VARIABLE"
+echo --my-flag	2	__MY_FLAG	echo "$__MY_FLAG"
+
+# Special chars become underscores
+path/to/file	1	PATH_TO_FILE	"$PATH_TO_FILE"
+key=value	1	KEY_VALUE	"$KEY_VALUE"
+user@host	1	USER_HOST	"$USER_HOST"
+
+# Numbers preserved
+var123	1	VAR123	"$VAR123"
+123start	1	123START	"$123START"
+a1b2c3	1	A1B2C3	"$A1B2C3"
+
+# Multiple special chars
+a--b__c	1	A__B__C	"$A__B__C"
+!!!bang	1	___BANG	"$___BANG"
+
+# Unicode to underscore
+café	1	CAF_	"$CAF_"
+
+# Real commands - extract argument
+kubectl get pods	3	PODS	kubectl get "$PODS"
+git commit -m message	4	MESSAGE	git commit -m "$MESSAGE"

--- a/tests/fixtures/wrap_cases.txt
+++ b/tests/fixtures/wrap_cases.txt
@@ -1,0 +1,46 @@
+# Wrap action test cases
+# Format: input<TAB>token_idx<TAB>wrapper_type<TAB>expected_buffer
+# TAB-separated to allow special characters
+
+# Double quotes
+echo foo bar	2	"..."	echo "foo" bar
+hello world	1	"..."	"hello" world
+abc	1	"..."	"abc"
+
+# Single quotes
+echo foo bar	2	'...'	echo 'foo' bar
+hello world	1	'...'	'hello' world
+
+# Quoted variable "$..."
+myvar	1	"$..."	"$myvar"
+echo foo	2	"$..."	echo "$foo"
+
+# Variable expansion ${...}
+myvar	1	${...}	${myvar}
+echo foo	2	${...}	echo ${foo}
+
+# Command substitution $(...)
+date	1	$(...)	$(date)
+echo cmd	2	$(...)	echo $(cmd)
+
+# Backtick legacy
+date	1	`...`	`date`
+
+# Square brackets
+test	1	[...]	[test]
+
+# Curly braces
+a,b,c	1	{...}	{a,b,c}
+
+# Parentheses
+subshell	1	(...)	(subshell)
+
+# Angle brackets
+file	1	<...>	<file>
+
+# Edge cases - special characters in tokens
+--flag=value	1	"..."	"--flag=value"
+"quoted"	1	'...'	'"quoted"'
+$var	1	"..."	"$var"
+🚀rocket	1	"..."	"🚀rocket"
+path/to/file	1	"..."	"path/to/file"

--- a/zsh-jumper.plugin.zsh
+++ b/zsh-jumper.plugin.zsh
@@ -10,70 +10,269 @@ typeset -gA ZshJumper
 ZshJumper[dir]="${0:h}"
 
 # ------------------------------------------------------------------------------
-# Picker Detection & Configuration
+# Configuration (read once at load time)
 # ------------------------------------------------------------------------------
-# Priority: zstyle > fzf-tmux (if in tmux) > fzf > sk > peco > percol
-#
-# Configure via zstyle:
+# Configure via zstyle BEFORE loading the plugin:
 #   zstyle ':zsh-jumper:' picker fzf
 #   zstyle ':zsh-jumper:' picker-opts '--height=10 --reverse'
 #   zstyle ':zsh-jumper:' disable-bindings yes
+#   zstyle ':zsh-jumper:' preview off
+#   zstyle ':zsh-jumper:' preview-window 'right:50%:wrap'
 # ------------------------------------------------------------------------------
 
-_zsh_jumper_detect_picker() {
+_zsh_jumper_load_config() {
     emulate -L zsh
+    local val
 
-    local picker
-    zstyle -s ':zsh-jumper:' picker picker
+    # Read all zstyle config once and store in ZshJumper array
+    zstyle -s ':zsh-jumper:' overlay val; ZshJumper[overlay]="${val:-on}"
+    zstyle -s ':zsh-jumper:' preview val; ZshJumper[preview]="${val:-on}"
+    zstyle -s ':zsh-jumper:' preview-window val; ZshJumper[preview-window]="${val:-right:50%:wrap}"
+    zstyle -s ':zsh-jumper:' cursor val; ZshJumper[cursor]="${val:-start}"
+    zstyle -s ':zsh-jumper:' picker-opts val; ZshJumper[picker-opts]="$val"
 
-    if [[ -n "$picker" ]]; then
-        (( $+commands[$picker] )) && { echo "$picker"; return 0 }
-        echo "zsh-jumper: configured picker '$picker' not found" >&2
-        return 1
-    fi
+    # FZF action keys
+    zstyle -s ':zsh-jumper:' fzf-wrap-key val; ZshJumper[wrap-key]="${val:-ctrl-s}"
+    zstyle -s ':zsh-jumper:' fzf-help-key val; ZshJumper[help-key]="${val:-ctrl-h}"
+    zstyle -s ':zsh-jumper:' fzf-var-key val; ZshJumper[var-key]="${val:-ctrl-e}"
+    zstyle -s ':zsh-jumper:' fzf-replace-key val; ZshJumper[replace-key]="${val:-ctrl-r}"
+    zstyle -s ':zsh-jumper:' fzf-instant-key val; ZshJumper[instant-key]="${val:-;}"
 
-    # Auto-detect: prefer fzf-tmux in tmux sessions
-    if [[ -n "$TMUX" ]] && (( $+commands[fzf-tmux] )); then
-        echo "fzf-tmux"
+    # Detect picker (prefer explicit config, then auto-detect)
+    zstyle -s ':zsh-jumper:' picker val
+    if [[ -n "$val" ]]; then
+        (( $+commands[$val] )) && ZshJumper[picker]="$val"
+    elif [[ -n "$TMUX" ]] && (( $+commands[fzf-tmux] )); then
+        ZshJumper[picker]="fzf-tmux"
     elif (( $+commands[fzf] )); then
-        echo "fzf"
+        ZshJumper[picker]="fzf"
     elif (( $+commands[sk] )); then
-        echo "sk"
+        ZshJumper[picker]="sk"
     elif (( $+commands[peco] )); then
-        echo "peco"
+        ZshJumper[picker]="peco"
     elif (( $+commands[percol] )); then
-        echo "percol"
+        ZshJumper[picker]="percol"
+    fi
+}
+
+_zsh_jumper_load_config
+
+# Result variables (set by adapters)
+typeset -g _zj_result_key _zj_result_selection
+
+# ------------------------------------------------------------------------------
+# Picker Adapters (Ports & Adapters pattern)
+# ------------------------------------------------------------------------------
+# Each adapter implements the same interface:
+#   Input:  items via stdin, config via _zj_invoke_* variables
+#   Output: _zj_result_key (action), _zj_result_selection (chosen item)
+#   Return: 0 = success, 1 = cancelled/error
+# ------------------------------------------------------------------------------
+
+_zsh_jumper_adapter_fzf() {
+    local -a base_opts=(--height=40% --reverse)
+    [[ -n "${ZshJumper[picker-opts]}" ]] && base_opts=(${(z)ZshJumper[picker-opts]})
+
+    local result
+    if [[ -n "$_zj_invoke_binds" ]]; then
+        result=$(fzf "${base_opts[@]}" \
+            --prompt="$_zj_invoke_prompt" \
+            --header="$_zj_invoke_header" \
+            --bind "$_zj_invoke_binds" \
+            "${_zj_invoke_preview_args[@]}")
+        _zj_result_key="${result%%$'\n'*}"
+        _zj_result_selection="${result#*$'\n'}"
     else
+        result=$(fzf "${base_opts[@]}" --prompt="$_zj_invoke_prompt")
+        _zj_result_key=""
+        _zj_result_selection="$result"
+    fi
+    [[ -n "$_zj_result_selection" ]]
+}
+
+_zsh_jumper_adapter_fzf-tmux() {
+    local -a base_opts=(--reverse)
+    [[ -n "${ZshJumper[picker-opts]}" ]] && base_opts=(${(z)ZshJumper[picker-opts]})
+
+    local result
+    if [[ -n "$_zj_invoke_binds" ]]; then
+        result=$(fzf-tmux "${base_opts[@]}" \
+            --prompt="$_zj_invoke_prompt" \
+            --header="$_zj_invoke_header" \
+            --bind "$_zj_invoke_binds" \
+            "${_zj_invoke_preview_args[@]}")
+        _zj_result_key="${result%%$'\n'*}"
+        _zj_result_selection="${result#*$'\n'}"
+    else
+        result=$(fzf-tmux "${base_opts[@]}" --prompt="$_zj_invoke_prompt")
+        _zj_result_key=""
+        _zj_result_selection="$result"
+    fi
+    [[ -n "$_zj_result_selection" ]]
+}
+
+_zsh_jumper_adapter_sk() {
+    local -a base_opts=(--height=40% --reverse)
+    [[ -n "${ZshJumper[picker-opts]}" ]] && base_opts=(${(z)ZshJumper[picker-opts]})
+
+    local result
+    if [[ -n "$_zj_invoke_binds" ]]; then
+        result=$(sk "${base_opts[@]}" \
+            --prompt="$_zj_invoke_prompt" \
+            --header="$_zj_invoke_header" \
+            --bind "$_zj_invoke_binds" \
+            "${_zj_invoke_preview_args[@]}")
+        _zj_result_key="${result%%$'\n'*}"
+        _zj_result_selection="${result#*$'\n'}"
+    else
+        result=$(sk "${base_opts[@]}" --prompt="$_zj_invoke_prompt")
+        _zj_result_key=""
+        _zj_result_selection="$result"
+    fi
+    [[ -n "$_zj_result_selection" ]]
+}
+
+_zsh_jumper_adapter_peco() {
+    local -a base_opts=()
+    [[ -n "${ZshJumper[picker-opts]}" ]] && base_opts=(${(z)ZshJumper[picker-opts]})
+
+    # peco doesn't support binds
+    _zj_result_key=""
+    _zj_result_selection=$(peco "${base_opts[@]}" --prompt="$_zj_invoke_prompt")
+    [[ -n "$_zj_result_selection" ]]
+}
+
+_zsh_jumper_adapter_percol() {
+    local -a base_opts=()
+    [[ -n "${ZshJumper[picker-opts]}" ]] && base_opts=(${(z)ZshJumper[picker-opts]})
+
+    # percol doesn't support binds
+    _zj_result_key=""
+    _zj_result_selection=$(percol "${base_opts[@]}" --prompt="$_zj_invoke_prompt")
+    [[ -n "$_zj_result_selection" ]]
+}
+
+# ------------------------------------------------------------------------------
+# Port: Unified Picker Interface
+# ------------------------------------------------------------------------------
+# Usage:
+#   printf '%s\n' "${items[@]}" | _zsh_jumper_invoke_picker <picker> <prompt> [header] [binds] [preview_args...]
+# Returns:
+#   _zj_result_key - action key (empty for basic selection)
+#   _zj_result_selection - selected item(s)
+# ------------------------------------------------------------------------------
+
+_zsh_jumper_invoke_picker() {
+    local picker="$1" prompt="$2" header="$3" binds="$4"
+    shift 4
+    local -a preview_args=("$@")
+
+    # Set invocation context for adapter
+    _zj_invoke_prompt="$prompt"
+    _zj_invoke_header="$header"
+    _zj_invoke_binds="$binds"
+    _zj_invoke_preview_args=("${preview_args[@]}")
+
+    # Clear results
+    _zj_result_key=""
+    _zj_result_selection=""
+
+    # Dispatch to adapter
+    local adapter_fn="_zsh_jumper_adapter_${picker}"
+    if (( $+functions[$adapter_fn] )); then
+        $adapter_fn
+    else
+        echo "zsh-jumper: unknown picker '$picker'" >&2
         return 1
     fi
 }
 
-_zsh_jumper_get_picker_opts() {
+_zsh_jumper_supports_binds() {
+    [[ "$1" == fzf* || "$1" == sk ]]
+}
+
+# ------------------------------------------------------------------------------
+# Overlay (visual hints on command line)
+# ------------------------------------------------------------------------------
+
+# Hint keys: home row first, then top row, then bottom
+typeset -ga _zj_hint_keys=(a s d f g h j k l \; q w e r t y u i o p z x c v b n m)
+
+_zsh_jumper_build_overlay() {
+    local -a hints=(a s d f g h j k l \; q w e r t y u i o p z x c v b n m)
+    local i=1 pos word last_end=0 result=""
+    while (( i <= ${#_zj_words[@]} )); do
+        pos=${_zj_positions[$i]}
+        word=${_zj_words[$i]}
+        result+="${BUFFER:$last_end:$((pos - last_end))}"
+        (( i <= 27 )) && result+="[${hints[$i]}]${word}" || result+="[${i}]${word}"
+        last_end=$((pos + ${#word}))
+        (( i++ ))
+    done
+    result+="${BUFFER:$last_end}"
+    REPLY="$result"
+}
+
+# Highlight hint keys [a] [s] etc with color via region_highlight
+_zsh_jumper_highlight_hints() {
+    region_highlight=()
+    local i=0 len=${#BUFFER}
+    while (( i < len - 2 )); do
+        if [[ "${BUFFER:$i:1}" == "[" && "${BUFFER:$((i+2)):1}" == "]" ]]; then
+            region_highlight+=("$i $((i+3)) fg=yellow,bold")
+            (( i += 3 ))
+        else
+            (( i++ ))
+        fi
+    done
+}
+
+# Map hint key back to word index
+_zsh_jumper_hint_to_index() {
+    local hint="$1" i
+    for i in {1..${#_zj_hint_keys[@]}}; do
+        [[ "${_zj_hint_keys[$i]}" == "$hint" ]] && { echo "$i"; return 0; }
+    done
+    # Fallback: if it's a number, use directly
+    [[ "$hint" =~ ^[0-9]+$ ]] && echo "$hint"
+}
+
+# ------------------------------------------------------------------------------
+# Tokenizer
+# ------------------------------------------------------------------------------
+
+_zsh_jumper_tokenize() {
     emulate -L zsh
+    _zj_words=()
+    _zj_positions=()
 
-    local picker="$1" opts
-    zstyle -s ':zsh-jumper:' picker-opts opts
+    local i=0 word_start=-1 in_word=0
+    local len=${#BUFFER}
 
-    if [[ -n "$opts" ]]; then
-        echo "$opts"
-        return
+    while (( i < len )); do
+        if [[ "${BUFFER:$i:1}" == [[:space:]] ]]; then
+            if (( in_word )); then
+                local word="${BUFFER:$word_start:$((i - word_start))}"
+                [[ "$word" != "\\" ]] && {
+                    _zj_words+=("$word")
+                    _zj_positions+=($word_start)
+                }
+                in_word=0
+            fi
+        elif (( ! in_word )); then
+            word_start=$i
+            in_word=1
+        fi
+        (( i++ ))
+    done
+
+    if (( in_word )); then
+        local word="${BUFFER:$word_start}"
+        [[ "$word" != "\\" ]] && {
+            _zj_words+=("$word")
+            _zj_positions+=($word_start)
+        }
     fi
-
-    # Sensible defaults per picker
-    case "$picker" in
-        fzf|fzf-tmux)
-            echo "--height=40% --reverse --prompt='jump> '"
-            ;;
-        sk)
-            echo "--height=40% --reverse --prompt='jump> '"
-            ;;
-        peco)
-            echo "--prompt='jump> '"
-            ;;
-        percol)
-            echo "--prompt='jump> '"
-            ;;
-    esac
 }
 
 # ------------------------------------------------------------------------------
@@ -82,56 +281,258 @@ _zsh_jumper_get_picker_opts() {
 
 zsh-jumper-widget() {
     emulate -L zsh
-    setopt local_options
+    setopt local_options no_xtrace no_verbose
 
-    local picker opts target
-
-    picker="$(_zsh_jumper_detect_picker)"
+    local picker="${ZshJumper[picker]}"
     if [[ -z "$picker" ]]; then
         zle -M "zsh-jumper: no picker found (install fzf, sk, peco, or percol)"
         return 1
     fi
 
-    local words=(${${${=BUFFER}:#}:#\\})
-    [[ ${#words[@]} -eq 0 ]] && return 0
+    _zsh_jumper_tokenize
+    [[ ${#_zj_words[@]} -eq 0 ]] && return 0
 
-    opts="$(_zsh_jumper_get_picker_opts "$picker")"
-
-    # Number words for accurate position tracking (handles -u vs --user)
-    local numbered=() i
-    for i in {1..${#words[@]}}; do
-        numbered+=("$i: ${words[$i]}")
+    # Build numbered list with hint keys
+    local -a numbered
+    local i hint
+    for i in {1..${#_zj_words[@]}}; do
+        if (( i <= ${#_zj_hint_keys[@]} )); then
+            hint="${_zj_hint_keys[$i]}"
+            numbered+=("[${hint}] $i: ${_zj_words[$i]}")
+        else
+            numbered+=("$i: ${_zj_words[$i]}")
+        fi
     done
 
-    local selection
-    selection=$(printf '%s\n' "${numbered[@]}" | eval "$picker $opts")
-    [[ -z "$selection" ]] && { zle redisplay; return 0; }
+    # Use pre-loaded config from ZshJumper array (no zstyle reads during widget)
+    local header="" binds=""
+    local -a preview_args=()
 
-    # Extract index and find position
-    local idx="${selection%%:*}"
-    target="${words[$idx]}"
+    if _zsh_jumper_supports_binds "$picker"; then
+        local wk=${ZshJumper[wrap-key]#ctrl-} hk=${ZshJumper[help-key]#ctrl-}
+        local vk=${ZshJumper[var-key]#ctrl-} rk=${ZshJumper[replace-key]#ctrl-}
+        header="^${(U)wk}:wrap | ^${(U)hk}:help | ^${(U)vk}:var | ^${(U)rk}:replace | ${ZshJumper[instant-key]}:instant"
 
-    if [[ -n "$target" ]]; then
-        # Calculate position by walking to Nth word
-        local pos=0 j=1 remaining="$BUFFER"
-        while (( j < idx )); do
-            local wpos="${remaining[(i)${words[$j]}]}"
-            (( pos += wpos + ${#words[$j]} - 1 ))
-            remaining="${remaining:$((wpos + ${#words[$j]} - 1))}"
-            (( j++ ))
+        # Build hint key bindings (a,s,d... print hint-X and accept)
+        local hint_binds="" unbind_hints="" rebind_hints="" k
+        for k in a s d f g h j k l q w e r t y u i o p z x c v b n m; do
+            hint_binds+=",$k:print(hint-$k)+accept"
+            unbind_hints+="${unbind_hints:++}unbind($k)"
+            rebind_hints+="${rebind_hints:++}rebind($k)"
         done
-        (( pos += ${remaining[(i)$target]} - 1 ))
-        local cursor_pos
-        zstyle -s ':zsh-jumper:' cursor cursor_pos || cursor_pos='start'
 
-        case "$cursor_pos" in
-            end)    (( pos >= 0 )) && CURSOR=$((pos + ${#target})) ;;
-            middle) (( pos >= 0 )) && CURSOR=$((pos + ${#target} / 2)) ;;
-            *)      (( pos >= 0 )) && CURSOR=$pos ;;
-        esac
+        # Start with hint keys unbound; ; rebinds them for instant mode
+        binds="start:${unbind_hints}"
+        binds+=",enter:print()+accept"
+        binds+=",${ZshJumper[wrap-key]}:print(wrap)+accept"
+        binds+=",${ZshJumper[help-key]}:print(help)+accept"
+        binds+=",${ZshJumper[var-key]}:print(var)+accept"
+        binds+=",${ZshJumper[replace-key]}:print(replace)+accept"
+        binds+=",${ZshJumper[instant-key]}:${rebind_hints}+change-prompt(HINT> )"
+        binds+="$hint_binds"
+
+        if [[ "${ZshJumper[preview]}" != "off" ]]; then
+            local preview_cmd='t="{}"; t="${t#*: }"; t="${t//\"/}"; t="${t//'"'"'/}"; [[ "$t" == *=* ]] && t="${t##*=}"; [[ "$t" == "~"* ]] && t="$HOME${t#"~"}"; [ -d "$t" ] && ls -la "$t" 2>/dev/null || [ -f "$t" ] && { command -v bat >/dev/null && bat --style=plain --color=always -n --line-range=:30 "$t" 2>/dev/null || head -30 "$t" 2>/dev/null; }'
+            preview_args=(--preview "$preview_cmd" --preview-window "${ZshJumper[preview-window]}")
+        fi
     fi
 
-    zle redisplay
+    # Always save original buffer (for safe restoration)
+    local saved_buffer="$BUFFER"
+
+    # Show overlay on command line with highlighted hints
+    if [[ "${ZshJumper[overlay]}" != "off" ]]; then
+        _zsh_jumper_build_overlay
+        BUFFER="$REPLY"
+        _zsh_jumper_highlight_hints
+        zle -R
+    fi
+
+    # Invoke picker via port (zle -I invalidates display for external command)
+    zle -I
+    printf '%s\n' "${numbered[@]}" | _zsh_jumper_invoke_picker "$picker" "jump> " "$header" "$binds" "${preview_args[@]}"
+
+    # Restore original buffer and clear highlights
+    region_highlight=()
+    BUFFER="$saved_buffer"
+
+    # Handle instant hint keys (hint-a, hint-s, etc)
+    if [[ "$_zj_result_key" == hint-* ]]; then
+        local hint_char="${_zj_result_key#hint-}"
+        local hint_idx="$(_zsh_jumper_hint_to_index "$hint_char")"
+        if [[ -n "$hint_idx" ]] && (( hint_idx >= 1 && hint_idx <= ${#_zj_words[@]} )); then
+            _zsh_jumper_do_jump "[${hint_char}] ${hint_idx}: ${_zj_words[$hint_idx]}"
+        fi
+        zle reset-prompt
+        return 0
+    fi
+
+    [[ -z "$_zj_result_selection" ]] && { zle reset-prompt; return 0; }
+
+    # Handle result based on action key
+    local -a selections=("${(@f)_zj_result_selection}")
+
+    case "$_zj_result_key" in
+        wrap)    _zsh_jumper_do_wrap "${selections[@]}" ;;
+        help)    _zsh_jumper_do_help "${selections[@]}" ;;
+        var)     _zsh_jumper_do_var "${selections[@]}" ;;
+        replace) _zsh_jumper_do_replace "${selections[@]}" ;;
+        *)       _zsh_jumper_do_jump "${selections[@]}" ;;
+    esac
+
+    zle reset-prompt
+}
+
+# ------------------------------------------------------------------------------
+# Actions
+# ------------------------------------------------------------------------------
+
+# Extract index from selection format: "[a] 1: word" or "1: word"
+_zsh_jumper_extract_index() {
+    local sel="$1"
+    # Strip hint prefix if present: "[a] 1: word" -> "1: word"
+    sel="${sel#\[?\] }"
+    sel="${sel#\[??\] }"
+    # Extract number before colon
+    echo "${sel%%:*}"
+}
+
+_zsh_jumper_do_jump() {
+    local sel="$1"
+    [[ -z "$sel" ]] && return 1
+
+    local idx="$(_zsh_jumper_extract_index "$sel")"
+    [[ "$idx" =~ ^[0-9]+$ ]] || return 1
+    (( idx < 1 || idx > ${#_zj_words[@]} )) && return 1
+
+    local pos="${_zj_positions[$idx]}"
+    local target="${_zj_words[$idx]}"
+
+    case "${ZshJumper[cursor]}" in
+        end)    CURSOR=$((pos + ${#target})) ;;
+        middle) CURSOR=$((pos + ${#target} / 2)) ;;
+        *)      CURSOR=$pos ;;
+    esac
+}
+
+_zsh_jumper_do_wrap() {
+    local sel="$1"
+    [[ -z "$sel" ]] && return 1
+
+    local idx="$(_zsh_jumper_extract_index "$sel")"
+    [[ "$idx" =~ ^[0-9]+$ ]] || return 1
+    (( idx < 1 || idx > ${#_zj_words[@]} )) && return 1
+
+    local pos="${_zj_positions[$idx]}"
+    local target="${_zj_words[$idx]}"
+
+    local wrappers='"..."   double quote
+'"'"'...'"'"'   single quote
+"$..."  quoted variable
+${...}  variable expansion
+$(...)  command substitution
+`...`   backtick / legacy subshell
+[...]   square brackets / test
+{...}   curly braces / brace expansion
+(...)   parentheses / subshell
+<...>   angle brackets / redirect'
+
+    zle -I
+    print -r -- "$wrappers" | _zsh_jumper_invoke_picker "${ZshJumper[picker]}" "wrap> " "Select wrapper" ""
+    [[ -z "$_zj_result_selection" ]] && return
+
+    local wrapper_type="${_zj_result_selection%%[[:space:]]*}"
+    local open close
+    case "$wrapper_type" in
+        '"..."')   open='"' close='"' ;;
+        "'...'")   open="'" close="'" ;;
+        '"$..."')  open='"$' close='"' ;;
+        '${...}')  open='${' close='}' ;;
+        '$(...)')  open='$(' close=')' ;;
+        '`...`')   open='`' close='`' ;;
+        '[...]')   open='[' close=']' ;;
+        '{...}')   open='{' close='}' ;;
+        '(...)')   open='(' close=')' ;;
+        '<...>')   open='<' close='>' ;;
+    esac
+
+    local end_pos=$((pos + ${#target}))
+    BUFFER="${BUFFER:0:$end_pos}${close}${BUFFER:$end_pos}"
+    BUFFER="${BUFFER:0:$pos}${open}${BUFFER:$pos}"
+    CURSOR=$((pos + ${#open}))
+}
+
+_zsh_jumper_do_help() {
+    local sel="$1"
+    [[ -z "$sel" ]] && return 1
+
+    local idx="$(_zsh_jumper_extract_index "$sel")"
+    [[ "$idx" =~ ^[0-9]+$ ]] || return 1
+    (( idx < 1 || idx > ${#_zj_words[@]} )) && return 1
+
+    local target="${_zj_words[$idx]}"
+    local cmd="${_zj_words[1]}"
+    local help_text=""
+
+    if [[ "$target" == -* ]] && (( $+commands[$cmd] )); then
+        local -a lines matching
+        lines=("${(@f)$("$cmd" --help 2>&1)}")
+        for line in "${lines[@]}"; do
+            [[ "$line" == *"$target"* ]] && matching+=("$line")
+            (( ${#matching[@]} >= 20 )) && break
+        done
+        help_text="${(F)matching}"
+    elif (( $+commands[$target] )); then
+        help_text=$("$target" --help 2>&1)
+    fi
+
+    if [[ -n "$help_text" ]]; then
+        print
+        print "=== $target ==="
+        print -r -- "$help_text"
+        print
+        zle reset-prompt
+    else
+        zle -M "No help for: $target"
+    fi
+}
+
+_zsh_jumper_do_var() {
+    emulate -L zsh
+    setopt local_options no_xtrace no_verbose
+
+    local sel="$1"
+    [[ -z "$sel" ]] && return 1
+
+    local idx="$(_zsh_jumper_extract_index "$sel")"
+    [[ "$idx" =~ ^[0-9]+$ ]] || return 1
+    (( idx < 1 || idx > ${#_zj_words[@]} )) && return 1
+
+    local pos="${_zj_positions[$idx]}"
+    local target="${_zj_words[$idx]}"
+    local var_name="${${(U)target}//[^A-Z0-9]/_}"
+    local end_pos=$((pos + ${#target}))
+
+    BUFFER="${BUFFER:0:$pos}\"\$${var_name}\"${BUFFER:$end_pos}"
+    CURSOR=$((pos + 1))
+    zle push-line
+    BUFFER="${var_name}=\"${target}\""
+    CURSOR=$((${#var_name} + 1))
+}
+
+_zsh_jumper_do_replace() {
+    local sel="$1"
+    [[ -z "$sel" ]] && return 1
+
+    local idx="$(_zsh_jumper_extract_index "$sel")"
+    [[ "$idx" =~ ^[0-9]+$ ]] || return 1
+    (( idx < 1 || idx > ${#_zj_words[@]} )) && return 1
+
+    local pos="${_zj_positions[$idx]}"
+    local target="${_zj_words[$idx]}"
+    local end_pos=$((pos + ${#target}))
+    BUFFER="${BUFFER:0:$pos}${BUFFER:$end_pos}"
+    CURSOR=$pos
 }
 
 zle -N zsh-jumper-widget
@@ -143,14 +544,12 @@ zle -N zsh-jumper-widget
 zsh-jumper-setup-bindings() {
     emulate -L zsh
 
-    # Check for opt-out
     if zstyle -t ':zsh-jumper:' disable-bindings; then
         return 0
     fi
 
     local key
     zstyle -s ':zsh-jumper:' binding key || key='^X/'
-
     bindkey "$key" zsh-jumper-widget
 }
 
@@ -163,16 +562,21 @@ zsh-jumper-setup-bindings
 zsh-jumper-unload() {
     emulate -L zsh
 
-    # Remove widget
     zle -D zsh-jumper-widget 2>/dev/null
 
-    # Remove functions
-    unfunction zsh-jumper-widget _zsh_jumper_detect_picker \
-               _zsh_jumper_get_picker_opts zsh-jumper-setup-bindings \
-               zsh-jumper-unload 2>/dev/null
+    unfunction zsh-jumper-widget _zsh_jumper_load_config \
+               _zsh_jumper_invoke_picker _zsh_jumper_tokenize \
+               _zsh_jumper_supports_binds _zsh_jumper_do_jump _zsh_jumper_do_wrap \
+               _zsh_jumper_do_help _zsh_jumper_do_var _zsh_jumper_do_replace \
+               _zsh_jumper_adapter_fzf _zsh_jumper_adapter_fzf-tmux \
+               _zsh_jumper_adapter_sk _zsh_jumper_adapter_peco \
+               _zsh_jumper_adapter_percol _zsh_jumper_extract_index \
+               _zsh_jumper_build_overlay _zsh_jumper_hint_to_index \
+               zsh-jumper-setup-bindings zsh-jumper-unload 2>/dev/null
 
-    # Clean up global state
-    unset 'ZshJumper[dir]'
+    unset '_zj_words' '_zj_positions' '_zj_result_key' '_zj_result_selection' \
+          '_zj_invoke_prompt' '_zj_invoke_header' '_zj_invoke_binds' \
+          '_zj_invoke_preview_args' 'ZshJumper[dir]'
     (( ${#ZshJumper} == 0 )) && unset ZshJumper
 
     return 0


### PR DESCRIPTION
## What

FZF actions via Ctrl+key bindings inside the picker:
- **Wrap** (^S): surround token in `"..."`, `$(...)`, `${...}`, etc
- **Help** (^H): show `--help` for selected flag/command
- **Var** (^E): extract token to `UPPERCASE` variable (uses push-line)
- **Replace** (^R): delete token and leave cursor for tab-completion

EasyMotion-style overlay hints:
- `[a] [s] [d]` labels shown on command line before picker opens
- Yellow highlighting via `region_highlight`
- Press `;` in fzf to toggle instant mode, then press letter to jump directly

## Architecture

- Ports & adapters pattern for picker abstraction (fzf, fzf-tmux, sk, peco, percol)
- Config read once at plugin load, stored in `ZshJumper` associative array
- Single-pass tokenizer records positions during parsing for O(1) lookup
- Data-driven test fixtures (91 tests)

## Credits

Overlay hints inspired by @DehanLUO's [zsh-easymotion](https://github.com/DehanLUO/.config/blob/main/zsh/zsh-easymotion/zsh-easymotion.zsh) - adapted `region_highlight` approach.

Closes #4